### PR TITLE
Add InlineDynamicModelSerializer Class

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('test_app.urls')),
 ]

--- a/docs/features/inline_dynamic_serializers.rst
+++ b/docs/features/inline_dynamic_serializers.rst
@@ -1,0 +1,177 @@
+Inline Dynamic Serializers
+========================
+
+The ``InlineDynamicModelSerializer`` allows you to create serializers on-the-fly without defining a serializer class. This is particularly useful for one-off serialization needs or when you need to dynamically create serializers based on runtime conditions.
+
+Basic Usage
+----------
+
+To use the ``InlineDynamicModelSerializer``, you need to provide a model parameter:
+
+.. code-block:: python
+
+    from shapeless_serializers.serializers import InlineDynamicModelSerializer
+    from myapp.models import Author
+
+    # Get an author instance
+    author = Author.objects.get(pk=1)
+
+    # Create an inline serializer with a model
+    serializer = InlineDynamicModelSerializer(author, model=Author)
+    serializer.data  # Contains all fields from the Author model
+
+
+Limiting Fields
+--------------
+
+You can limit the fields included in the serialized output:
+
+.. code-block:: python
+
+    serializer = InlineDynamicModelSerializer(
+        author, 
+        model=Author, 
+        fields=['name', 'bio']
+    )
+    serializer.data  # Contains only 'name' and 'bio' fields
+
+
+Nested Relationships
+------------------
+
+You can include related models in the serialized output:
+
+.. code-block:: python
+
+    from myapp.models import Book
+
+    book = Book.objects.get(pk=1)
+
+    serializer = InlineDynamicModelSerializer(
+        book,
+        model=Book,
+        fields=['title', 'author', 'price'],
+        nested={
+            'author': {
+                'serializer': InlineDynamicModelSerializer,
+                'model': Author,
+                'fields': ['name', 'bio']
+            }
+        }
+    )
+    serializer.data  # Contains 'title', 'price', and nested 'author' with 'name' and 'bio'
+
+
+Field Renaming
+------------
+
+You can rename fields in the serialized output:
+
+.. code-block:: python
+
+    serializer = InlineDynamicModelSerializer(
+        author,
+        model=Author,
+        rename_fields={'name': 'author_name', 'bio': 'biography'}
+    )
+    serializer.data  # Contains 'author_name' and 'biography' instead of 'name' and 'bio'
+
+
+Conditional Fields
+---------------
+
+You can conditionally include or exclude fields based on conditions:
+
+.. code-block:: python
+
+    # Only include bio if show_bio is True
+    show_bio = request.query_params.get('show_bio', '').lower() == 'true'
+
+    serializer = InlineDynamicModelSerializer(
+        author,
+        model=Author,
+        conditional_fields={
+            'bio': show_bio
+        }
+    )
+    serializer.data  # Contains 'bio' only if show_bio is True
+
+
+Field Attributes
+--------------
+
+You can modify field attributes dynamically:
+
+.. code-block:: python
+
+    serializer = InlineDynamicModelSerializer(
+        book,
+        model=Book,
+        field_attributes={
+            'title': {'read_only': True},  # Make title read-only
+            'price': {'label': 'Retail Price', 'help_text': 'Price in USD'}
+        }
+    )
+
+
+Multiple Instances
+---------------
+
+You can serialize multiple instances by setting ``many=True``:
+
+.. code-block:: python
+
+    authors = Author.objects.all()
+
+    serializer = InlineDynamicModelSerializer(
+        authors,
+        model=Author,
+        many=True,
+        fields=['id', 'name']
+    )
+    serializer.data  # Contains a list of authors with 'id' and 'name' fields
+
+
+Complex Example
+-------------
+
+You can combine multiple features for complex serialization needs:
+
+.. code-block:: python
+
+    from myapp.models import BlogPost, AuthorProfile, Tag, Category, User
+
+    post = BlogPost.objects.get(pk=1)
+
+    serializer = InlineDynamicModelSerializer(
+        post,
+        model=BlogPost,
+        fields=['title', 'content', 'author', 'tags', 'categories'],
+        nested={
+            'author': {
+                'serializer': InlineDynamicModelSerializer,
+                'model': AuthorProfile,
+                'fields': ['bio', 'user'],
+                'nested': {
+                    'user': {
+                        'serializer': InlineDynamicModelSerializer,
+                        'model': User,
+                        'fields': ['username', 'email']
+                    }
+                }
+            },
+            'tags': {
+                'serializer': InlineDynamicModelSerializer,
+                'model': Tag,
+                'fields': ['name'],
+                'many': True
+            },
+            'categories': {
+                'serializer': InlineDynamicModelSerializer,
+                'model': Category,
+                'fields': ['name'],
+                'many': True
+            }
+        },
+        rename_fields={'title': 'post_title'}
+    )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,4 +16,5 @@ Welcome to the DRF Shapeless Serializers documentation.
    features/conditional_fields
    features/nested_serializers
    features/custom_serializers
+   features/inline_dynamic_serializers
    examples

--- a/shapeless_serializers/mixins.py
+++ b/shapeless_serializers/mixins.py
@@ -346,3 +346,16 @@ class DynamicNestedSerializerMixin(DynamicSerializerBaseMixin):
         serializer_kwargs.update(params_copy)
 
         return serializer_class(**serializer_kwargs)
+
+class InlineDynamicSerializerMixin:
+    """Inline dynamic serializer mixin that dynamically sets Meta.model and Meta.fields."""
+
+    def __init__(self, *args, **kwargs):
+        model = kwargs.pop("model", None)
+        if model:
+            meta = getattr(self, 'Meta', type('Meta', (), {}))
+            meta.model = model
+            meta.fields = '__all__'
+            self.Meta = meta
+        super().__init__(*args, **kwargs)
+

--- a/shapeless_serializers/serializers.py
+++ b/shapeless_serializers/serializers.py
@@ -6,6 +6,7 @@ from shapeless_serializers.mixins import (
     DynamicFieldRenamingMixin,
     DynamicFieldsMixin,
     DynamicNestedSerializerMixin,
+    InlineDynamicSerializerMixin,
 )
 
 
@@ -30,6 +31,12 @@ class ShapelessModelSerializer(
 ):
     pass
 
+class InlineDynamicModelSerializer(
+    InlineDynamicSerializerMixin,
+    ShapelessModelSerializer,
+    serializers.ModelSerializer,
+):
+    pass
 
 class ShapelessHyperlinkedModelSerializer(serializers.HyperlinkedModelSerializer):
     pass

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,11 +1,13 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-from .models import Book
+from .models import Book, Author
 
 from .serializers import (
     DynamicBookSerializer,
     DynamicAuthorSerializer,
     UserSerializer)
+
+from shapeless_serializers.serializers import InlineDynamicModelSerializer
 
 from rest_framework.validators import (
     UniqueValidator,
@@ -56,3 +58,37 @@ def create_book(request):
         serializer.save()
         return Response(serializer.data, status=201)
     return Response(serializer.errors, status=400)
+
+
+# Examples of InlineDynamicModelSerializer usage
+
+@api_view(['GET'])
+def author_detail_inline(request, pk):
+    """
+    Example of using InlineDynamicModelSerializer with basic model parameter.
+    This demonstrates how to create a serializer on-the-fly without defining a serializer class.
+    """
+    author = Author.objects.get(pk=pk)
+    
+    # Create an inline serializer with a model
+    serializer = InlineDynamicModelSerializer(author, model=Author)
+    
+    return Response(serializer.data)
+
+
+@api_view(['GET'])
+def book_detail_inline(request, pk):
+    """
+    Example of using InlineDynamicModelSerializer with fields parameter.
+    This demonstrates how to limit the fields in the serialized output.
+    """
+    book = Book.objects.get(pk=pk)
+    
+    # Create an inline serializer with a model and fields
+    serializer = InlineDynamicModelSerializer(
+        book, 
+        model=Book, 
+        fields=['title', 'price']
+    )
+    
+    return Response(serializer.data)

--- a/tests/test_inline_dynamic_model_serializer.py
+++ b/tests/test_inline_dynamic_model_serializer.py
@@ -1,0 +1,242 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from shapeless_serializers.serializers import InlineDynamicModelSerializer
+from shapeless_serializers.exceptions import DynamicSerializerConfigError
+from test_app.models import Author, Book, BlogPost, AuthorProfile, Tag, Category
+
+User = get_user_model()
+
+
+class InlineDynamicModelSerializerTests(TestCase):
+    """Tests for the InlineDynamicModelSerializer class."""
+
+    def setUp(self):
+        # Create test users
+        self.user1 = User.objects.create(username="user1", email="user1@example.com")
+        
+        # Create test authors
+        self.author1 = Author.objects.create(name="Test Author", bio="Author biography")
+        
+        # Create test books
+        self.book1 = Book.objects.create(
+            title="Test Book",
+            author=self.author1,
+            price=29.99,
+            publication_date="2023-01-01"
+        )
+        
+        # Create author profile
+        self.author_profile = AuthorProfile.objects.create(
+            user=self.user1, 
+            bio="Author bio", 
+            website="https://author.com"
+        )
+        
+        # Create blog post
+        self.post = BlogPost.objects.create(
+            title="Test Post",
+            slug="test-post",
+            author=self.author_profile,
+            content="Test content",
+        )
+        
+        # Create tags and categories
+        self.tag1 = Tag.objects.create(name="Django", slug="django")
+        self.category1 = Category.objects.create(name="Technology", slug="tech")
+
+    def test_inline_serializer_with_model(self):
+        """Test that InlineDynamicModelSerializer correctly sets model and fields."""
+        # Create an inline serializer with a model
+        serializer = InlineDynamicModelSerializer(self.author1, model=Author)
+        
+        # Check that the serializer has the correct model and fields
+        self.assertEqual(serializer.Meta.model, Author)
+        self.assertEqual(serializer.Meta.fields, '__all__')
+        
+        # Check that the serializer data contains the expected fields
+        data = serializer.data
+        self.assertIn('name', data)
+        self.assertIn('bio', data)
+        self.assertEqual(data['name'], 'Test Author')
+        self.assertEqual(data['bio'], 'Author biography')
+
+    def test_inline_serializer_with_fields(self):
+        """Test that InlineDynamicModelSerializer works with fields parameter."""
+        # Create an inline serializer with a model and fields
+        serializer = InlineDynamicModelSerializer(
+            self.book1, 
+            model=Book, 
+            fields=['title', 'price']
+        )
+        
+        # Check that the serializer data contains only the specified fields
+        data = serializer.data
+        self.assertIn('title', data)
+        self.assertIn('price', data)
+        self.assertNotIn('publication_date', data)
+        self.assertEqual(data['title'], 'Test Book')
+        self.assertEqual(float(data['price']), 29.99)
+
+    def test_inline_serializer_with_nested(self):
+        """Test that InlineDynamicModelSerializer works with nested parameter."""
+        # Create an inline serializer with nested relationships
+        serializer = InlineDynamicModelSerializer(
+            self.book1,
+            model=Book,
+            fields=['title', 'author'],
+            nested={
+                'author': {
+                    'serializer': InlineDynamicModelSerializer,
+                    'model': Author,
+                    'fields': ['name']
+                }
+            }
+        )
+        
+        # Check that the serializer data contains the nested relationship
+        data = serializer.data
+        self.assertIn('author', data)
+        self.assertIn('name', data['author'])
+        self.assertEqual(data['author']['name'], 'Test Author')
+
+    def test_inline_serializer_with_field_attributes(self):
+        """Test that InlineDynamicModelSerializer works with field_attributes parameter."""
+        # Create an inline serializer with field attributes
+        serializer = InlineDynamicModelSerializer(
+            self.author1,
+            model=Author,
+            field_attributes={
+                'name': {'read_only': True},
+                'bio': {'required': False}
+            }
+        )
+        
+        # Check that the field attributes were applied
+        self.assertTrue(serializer.fields['name'].read_only)
+        self.assertFalse(serializer.fields['bio'].required)
+
+    def test_inline_serializer_with_rename_fields(self):
+        """Test that InlineDynamicModelSerializer works with rename_fields parameter."""
+        # Create an inline serializer with renamed fields
+        serializer = InlineDynamicModelSerializer(
+            self.author1,
+            model=Author,
+            rename_fields={'name': 'author_name', 'bio': 'biography'}
+        )
+        
+        # Check that the fields were renamed in the output
+        data = serializer.data
+        self.assertIn('author_name', data)
+        self.assertIn('biography', data)
+        self.assertNotIn('name', data)
+        self.assertNotIn('bio', data)
+        self.assertEqual(data['author_name'], 'Test Author')
+        self.assertEqual(data['biography'], 'Author biography')
+
+    def test_inline_serializer_with_conditional_fields(self):
+        """Test that InlineDynamicModelSerializer works with conditional_fields parameter."""
+        # Create an inline serializer with conditional fields
+        serializer = InlineDynamicModelSerializer(
+            self.author1,
+            model=Author,
+            conditional_fields={
+                'bio': False  # Exclude bio field
+            }
+        )
+        
+        # Check that the conditional fields were applied
+        data = serializer.data
+        self.assertIn('name', data)
+        self.assertNotIn('bio', data)
+
+    def test_inline_serializer_without_model(self):
+        """Test that InlineDynamicModelSerializer works without model parameter."""
+        # Create a subclass with Meta class
+        class AuthorInlineSerializer(InlineDynamicModelSerializer):
+            class Meta:
+                model = Author
+                fields = ['name']
+        
+        # Create an instance of the serializer
+        serializer = AuthorInlineSerializer(self.author1)
+        
+        # Check that the serializer data contains the expected fields
+        data = serializer.data
+        self.assertIn('name', data)
+        self.assertNotIn('bio', data)
+        self.assertEqual(data['name'], 'Test Author')
+
+    def test_inline_serializer_many_true(self):
+        """Test that InlineDynamicModelSerializer works with many=True."""
+        # Create multiple authors
+        author2 = Author.objects.create(name="Second Author", bio="Another biography")
+        authors = [self.author1, author2]
+        
+        # Create an inline serializer with many=True
+        serializer = InlineDynamicModelSerializer(
+            authors,
+            model=Author,
+            many=True,
+            fields=['name']
+        )
+        
+        # Check that the serializer data contains multiple items
+        data = serializer.data
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['name'], 'Test Author')
+        self.assertEqual(data[1]['name'], 'Second Author')
+
+    def test_inline_serializer_complex_case(self):
+        """Test a complex case with multiple features combined."""
+        # Create an inline serializer with multiple features
+        serializer = InlineDynamicModelSerializer(
+            self.post,
+            model=BlogPost,
+            fields=['title', 'content', 'author', 'tags', 'categories'],
+            nested={
+                'author': {
+                    'serializer': InlineDynamicModelSerializer,
+                    'model': AuthorProfile,
+                    'fields': ['bio', 'user'],
+                    'nested': {
+                        'user': {
+                            'serializer': InlineDynamicModelSerializer,
+                            'model': User,
+                            'fields': ['username', 'email']
+                        }
+                    }
+                },
+                'tags': {
+                    'serializer': InlineDynamicModelSerializer,
+                    'model': Tag,
+                    'fields': ['name'],
+                    'many': True
+                },
+                'categories': {
+                    'serializer': InlineDynamicModelSerializer,
+                    'model': Category,
+                    'fields': ['name'],
+                    'many': True
+                }
+            },
+            rename_fields={'title': 'post_title'}
+        )
+        
+        # Check the complex serializer output
+        data = serializer.data
+        
+        # Check renamed fields
+        self.assertIn('post_title', data)
+        self.assertEqual(data['post_title'], 'Test Post')
+        
+        # Check nested author and user
+        self.assertIn('author', data)
+        self.assertIn('bio', data['author'])
+        self.assertIn('user', data['author'])
+        self.assertIn('username', data['author']['user'])
+        self.assertEqual(data['author']['user']['username'], 'user1')
+        
+        # Check that tags and categories are properly serialized
+        self.assertIn('tags', data)
+        self.assertIn('categories', data)


### PR DESCRIPTION
What is InlineDynamicModelSerializer?
The InlineDynamicModelSerializer is a powerful feature that allows developers to create Django REST Framework serializers on-the-fly without defining a separate serializer class.

Benefits
- Provides clear, practical examples of how to use InlineDynamicModelSerializer
- Demonstrates the flexibility of creating serializers on-the-fly
- Makes it easier for users to understand and adopt this feature
- Reduces boilerplate code in Django REST Framework applications